### PR TITLE
Fix query selector in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Status must be the full response of [GET statuses/show/:id](https://developer.tw
 ```
 
 ```
-document.querySelector('<twitter-status>').status = { "id_str": "20", ... };
+document.querySelector('twitter-status').status = { "id_str": "20", ... };
 
 ```
 


### PR DESCRIPTION
current example query selector fails with

```
> document.querySelector('<twitter-status>').status
VM1251:1 Uncaught DOMException: Failed to execute 'querySelector' on 'Document': '<twitter-status>' is not a valid selector.
```